### PR TITLE
Add other common docfx assets

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+# Builds and publishes the documentation website to gh-pages branch
+name: Build docs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          submodules: true
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v4.0.0
+        with:
+          dotnet-version: 7.x
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+        
+      - name: Restore NuGet Packages
+        run: msbuild -t:restore src/Bonsai.PackageName.sln
+
+      - name: Build Solution
+        run: msbuild src/Bonsai.PackageName.sln /p:Configuration=Release
+        
+      - name: Setup DocFX
+        run: dotnet tool restore
+
+      - name: Setup Bonsai
+        working-directory: .bonsai
+        run: ./Setup.ps1
+        
+      - name: Build Documentation
+        working-directory: docs
+        run: ./build.ps1
+
+      - name: Publish to github pages
+        uses: peaceiris/actions-gh-pages@v3.9.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_site
+          publish_branch: gh-pages
+          force_orphan: true

--- a/README.md
+++ b/README.md
@@ -4,23 +4,13 @@ Common assets used for package documentation.
 
 ## How to use
 
-To use these assets in a docfx website, first clone this repository as a submodule:
+1) Download these assets and place them in the following locations:
 
-```
-git submodule add https://github.com/bonsai-rx/docfx-assets assets
-```
+`favicon.ico`, `logo.svg`, `build.ps1` - in `docs/` folder
+`template/public/main.css and main.js` - in `docs/` folder (keep folder structure)
+`.github/workflows/docs.yml` - in root directory of repository (keep folder structure)
 
-Then modify `docfx.json` to include the asset files under the `"resource"` section:
-
-```json
-      {
-        "files": [
-          "logo.svg",
-          "favicon.ico"
-        ],
-        "src": "assets"
-      }
-```
+2) Edit `PackageName` in `docs.yml`, `build.ps1` and `main.js` to reflect the packagename of the repository being set up.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Common assets used for package documentation.
 1) Download these assets and place them in the following locations:
 
 `favicon.ico`, `logo.svg`, `build.ps1` - in `docs/` folder
+
 `template/public/main.css and main.js` - in `docs/` folder (keep folder structure)
+
 `.github/workflows/docs.yml` - in root directory of repository (keep folder structure)
 
 2) Edit `PackageName` in `docs.yml`, `build.ps1` and `main.js` to reflect the packagename of the repository being set up.

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,2 @@
+.\bonsai\modules\Export-Image.ps1 "..\src\Bonsai.PackageName\bin\Release\net462"
+dotnet docfx @args

--- a/template/public/main.css
+++ b/template/public/main.css
@@ -1,0 +1,1 @@
+@import "workflow.css";

--- a/template/public/main.js
+++ b/template/public/main.js
@@ -1,0 +1,13 @@
+import WorkflowContainer from "./workflow.js"
+
+export default {
+    defaultTheme: 'auto',
+    iconLinks: [{
+        icon: 'github',
+        href: 'https://github.com/bonsai-rx/PackageName',
+        title: 'GitHub'
+    }],
+    start: () => {
+        WorkflowContainer.init();
+    }
+}


### PR DESCRIPTION
Resolves #1 

The github actions workflow and template/public was taken from machinelearning repository.
The build.ps1 was taken from pulsepal repository (since the machinelearning version seems to be extended for the examples submodule)

Package names in those files were replaced with a generic `PackageName` to indicate to users that they should change it and the README was updated to reflect that.

